### PR TITLE
fix: add Secure and SameSite attributes to dev layer cookie

### DIFF
--- a/dl/dl.go
+++ b/dl/dl.go
@@ -95,6 +95,8 @@ func (c *Client) download(ctx context.Context, layer int, key string) ([]byte, e
 			Value: strconv.Itoa(layer),
 
 			HttpOnly: true,
+			Secure:   true,
+			SameSite: http.SameSiteStrictMode,
 		})
 	}
 


### PR DESCRIPTION
Resolves the gosec G124 golangci-lint warning by adding `Secure` and `SameSite` attributes to the `stel_dev_layer` cookie in `dl/dl.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)